### PR TITLE
Ensure Flyway compatibility

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   mariadb:
-    image: 'mariadb:latest'
+    image: 'mariadb:11.2'
     environment:
       - 'MARIADB_DATABASE=${mariadb_database}'
       - 'MARIADB_PASSWORD=${mariadb_user_password}'


### PR DESCRIPTION
Flyway upgrade recommended: MariaDB 11.3 is newer than this version of Flyway and support has not been tested. The latest supported version of MariaDB is 11.2.